### PR TITLE
Get curriculum info from autotrain

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install aind-analysis-arch-result-access
 
 Try the demo: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/14Hph9QuySbgSQBKl8PGi_nCQfoLcLUI-?usp=sharing)
 
-### Access pipeline v1.0 (Han's pipeline)
+### Access pipeline v1.0 (Han's "temporary" pipeline)
 #### Fetch the session master table in [Streamlit](https://foraging-behavior-browser.allenneuraldynamics-test.org/)
 ```python
 from aind_analysis_arch_result_access.han_pipeline import get_session_table

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ exclude = '''
 '''
 
 [tool.coverage.run]
-omit = ["*__init__*"]
+omit = ["*__init__*", "s3.py"]
 source = ["aind_analysis_arch_result_access", "tests"]
 
 [tool.coverage.report]

--- a/src/aind_analysis_arch_result_access/han_pipeline.py
+++ b/src/aind_analysis_arch_result_access/han_pipeline.py
@@ -69,7 +69,10 @@ def get_session_table(if_load_bpod=False, only_recent_n_month=None) -> pd.DataFr
         # Filter to only recent N months
         cutoff_date = pd.Timestamp.now() - pd.DateOffset(months=only_recent_n_month)
         df = df[df["session_date"] >= cutoff_date]
-        logger.info(f"Filtered to sessions from {cutoff_date.date()} onwards (recent {only_recent_n_month} months). Remaining sessions: {len(df)}")
+        logger.info(
+            f"Filtered to sessions from {cutoff_date.date()} onwards "
+            f"(recent {only_recent_n_month} months). Remaining sessions: {len(df)}"
+        )
 
     logger.info("Post-hoc processing...")
 
@@ -189,7 +192,7 @@ def get_session_table(if_load_bpod=False, only_recent_n_month=None) -> pd.DataFr
         "if_overriden_by_trainer",
     ]
     df = df.drop(columns=[col for col in columns_to_drop if col in df.columns])
-    
+
     # Merge curriculum info autotrain database
     df = df.merge(
         df_autotrain.query("if_closed_loop == True")[
@@ -254,20 +257,23 @@ def get_session_table(if_load_bpod=False, only_recent_n_month=None) -> pd.DataFr
 
     return df
 
+
 def get_autotrain_table():
     """
     Load the curriculum data from Han's autotrain database directly from a (duplicated) s3 bucket.
       s3://aind-behavior-data/foraging_nwb_bonsai_processed/foraging_auto_training/df_manager_447_demo.pkl
-    
-    
+
+
     """
-    df_autotrain = get_s3_pkl(
-        "s3://aind-behavior-data/foraging_nwb_bonsai_processed/foraging_auto_training/df_manager_447_demo.pkl"
+    s3_path = (
+        "s3://aind-behavior-data/foraging_nwb_bonsai_processed/"
+        "foraging_auto_training/df_manager_447_demo.pkl"
     )
+    df_autotrain = get_s3_pkl(s3_path)
     df_autotrain["session_date"] = pd.to_datetime(df_autotrain["session_date"])
-    
+
     logger.info("Loaded curriculum data from Han's autotrain.")
-    return df_autotrain 
+    return df_autotrain
 
 
 def get_mle_model_fitting(

--- a/src/aind_analysis_arch_result_access/han_pipeline.py
+++ b/src/aind_analysis_arch_result_access/han_pipeline.py
@@ -201,6 +201,7 @@ def get_session_table(if_load_bpod=False, only_recent_n_month=None) -> pd.DataFr
                 "curriculum_schema_version",
                 "current_stage_suggested",
                 "current_stage_actual",
+                "session_at_current_stage",
                 "decision",
                 "next_stage_suggested",
                 "if_overriden_by_trainer",

--- a/src/aind_analysis_arch_result_access/han_pipeline.py
+++ b/src/aind_analysis_arch_result_access/han_pipeline.py
@@ -65,10 +65,10 @@ def get_session_table(if_load_bpod=False, only_recent_n_month=None) -> pd.DataFr
     df.columns = df.columns.get_level_values(1)
     df.sort_values(["session_start_time"], ascending=False, inplace=True)
     df["session_start_time"] = df["session_start_time"].astype(str)  # Turn to string
-    df["session_date"] = pd.to_datetime(df["session_date"])
     df = df.reset_index()
 
     # Filter sessions by date if requested (early filtering for performance)
+    df["session_date"] = pd.to_datetime(df["session_date"])
     if only_recent_n_month is not None:
         # Filter to only recent N months
         cutoff_date = pd.Timestamp.now() - pd.DateOffset(months=only_recent_n_month)

--- a/tests/test_get_han_pipeline.py
+++ b/tests/test_get_han_pipeline.py
@@ -3,7 +3,6 @@
 import unittest
 
 import pandas as pd
-import datetime
 
 from aind_analysis_arch_result_access.han_pipeline import (
     get_logistic_regression,
@@ -27,23 +26,25 @@ class TestGetMasterSessionTable(unittest.TestCase):
         self.assertIsNotNone(df)
         self.assertGreater(len(df_bpod), len(df))
         print(df_bpod.head())
-        
+
     def test_get_recent_sessions(self):
         """Test get session table for sessions from the last 6 months."""
-        
+
         # Get sessions from the last 6 months using the parameter
         months = 6
         df = get_session_table(if_load_bpod=False, only_recent_n_month=months)
         self.assertIsNotNone(df)
-        
+
         # Calculate date 6 months ago using the same method as the pipeline
         cutoff_date = pd.Timestamp.now() - pd.DateOffset(months=months)
-                
+
         # Verify no session is earlier than 6 months ago
-        self.assertTrue((df['session_date'] >= cutoff_date).all(), 
-                       f"Found sessions older than {cutoff_date.date()}. "
-                       f"Earliest session: {df['session_date'].min()}")
-        
+        self.assertTrue(
+            (df["session_date"] >= cutoff_date).all(),
+            f"Found sessions older than {cutoff_date.date()}. "
+            f"Earliest session: {df['session_date'].min()}",
+        )
+
         # Verify we have some recent sessions
         self.assertGreater(len(df), 0)
         print(f"Found {len(df)} sessions in the last {months} months")

--- a/tests/test_get_han_pipeline.py
+++ b/tests/test_get_han_pipeline.py
@@ -3,6 +3,7 @@
 import unittest
 
 import pandas as pd
+import datetime
 
 from aind_analysis_arch_result_access.han_pipeline import (
     get_logistic_regression,
@@ -26,6 +27,30 @@ class TestGetMasterSessionTable(unittest.TestCase):
         self.assertIsNotNone(df)
         self.assertGreater(len(df_bpod), len(df))
         print(df_bpod.head())
+        
+    def test_get_recent_sessions(self):
+        """Test get session table for sessions from the last 6 months."""
+        
+        # Get sessions from the last 6 months using the parameter
+        months = 6
+        df = get_session_table(if_load_bpod=False, only_recent_n_month=months)
+        self.assertIsNotNone(df)
+        
+        # Calculate date 6 months ago using the same method as the pipeline
+        cutoff_date = pd.Timestamp.now() - pd.DateOffset(months=months)
+                
+        # Verify no session is earlier than 6 months ago
+        self.assertTrue((df['session_date'] >= cutoff_date).all(), 
+                       f"Found sessions older than {cutoff_date.date()}. "
+                       f"Earliest session: {df['session_date'].min()}")
+        
+        # Verify we have some recent sessions
+        self.assertGreater(len(df), 0)
+        print(f"Found {len(df)} sessions in the last {months} months")
+        print(f"Cutoff date: {cutoff_date.date()}")
+        print(f"Earliest session: {df['session_date'].min()}")
+        print(f"Latest session: {df['session_date'].max()}")
+        print(df.head())
 
 
 class TestGetMLEModelFitting(unittest.TestCase):


### PR DESCRIPTION
Instead of relying on my temporary pipeline (getting from behavior json), we should retrieve curriculum info from the curriculum system. This PR switches the curriculum data source from Han's temporary pipeline to his autotrain. But soon we will be adding SLIMS, the database for our new curriculum system.
