### PR TITLE
found bug-- returned latents were just from one record

### DIFF
--- a/src/aind_analysis_arch_result_access/han_pipeline.py
+++ b/src/aind_analysis_arch_result_access/han_pipeline.py
@@ -357,7 +357,7 @@ def add_qvalue_spread(latents):
             continue
         uniform_ratio = entropy(prob, base=2) / max_entropy
         latent["qvalue_spread"] = uniform_ratio
-    return latent
+    return latents
 
 
 def get_mle_model_fitting(


### PR DESCRIPTION
small issue when i changed the code to fix https://github.com/AllenNeuralDynamics/aind-analysis-arch-result-access/issues/22


fixing this.... the returned latent was only for one record